### PR TITLE
Disable PossibleFragmentSpreadsRule validation

### DIFF
--- a/rules.go
+++ b/rules.go
@@ -27,7 +27,7 @@ var SpecifiedRules = []ValidationRuleFn{
 	NoUnusedFragmentsRule,
 	NoUnusedVariablesRule,
 	OverlappingFieldsCanBeMergedRule,
-	PossibleFragmentSpreadsRule,
+	// PossibleFragmentSpreadsRule, <-- commented out for Attic
 	ProvidedNonNullArgumentsRule,
 	ScalarLeafsRule,
 	UniqueArgumentNamesRule,


### PR DESCRIPTION
This is so we can use fragments even when the type does not match